### PR TITLE
fix build after a69c1c53cb48e7aa861af0e076f6f5e69fb82835

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 CC = cc
-CFLAGS = -O2 -g -I$(libswftag_lib_root)/include -Wall -std=c99 -pedantic
+CFLAGS = -O2 -g -I$(libswftag_root)/include -Wall -std=c99 -pedantic
 
+libswftag_root = ../libswftag
 libswftag_lib_root = ../libswftag/lib
 
 objs = \
@@ -11,7 +12,7 @@ swfcheck: $(objs) $(libswftag_lib_root)/libswftag.a
 	$(CC) $(CFLAGS) $^ -o $@
 
 $(libswftag_lib_root)/libswftag.a:
-	$(MAKE) -C $(libswftag_lib_root)
+	$(MAKE) -C $(libswftag_root)
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@


### PR DESCRIPTION
include dir is still at top level